### PR TITLE
ONVIF service available/controllable from MQTT

### DIFF
--- a/firmware_mod/scripts/mqtt-control.sh
+++ b/firmware_mod/scripts/mqtt-control.sh
@@ -432,5 +432,19 @@ done
 	  # Publish updated states
 	  /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -m "$(/system/sdcard/scripts/mqtt-status.sh)"
 	;;
+	
+	"${TOPIC}/onvif")
+	  /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/onvif ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -m "$(onvif_srvd status)"
+	;;
+
+	"${TOPIC}/onvif/set ON")
+	  onvif_srvd on
+	  /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/onvif ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -m "$(onvif_srvd status)"
+	;;
+
+	"${TOPIC}/onvif/set OFF")
+	  onvif_srvd off
+	  /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/onvif ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -m "$(onvif_srvd status)"
+	;;
   esac
 done


### PR DESCRIPTION
ONVIF service was added via PR [1296](https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/pull/1296) and controllable via camera UI, but not from MQTT.

Purpose of this PR is to allow ONVIF service to be available/controllable from MQTT